### PR TITLE
Fix `:memoize_for_arguments` and add tests to verify built-in decorators

### DIFF
--- a/lib/adornable/decorators.rb
+++ b/lib/adornable/decorators.rb
@@ -7,7 +7,7 @@ module Adornable
         [method_receiver.class.to_s, '#']
       end
       full_name = "`#{receiver_name}#{name_delimiter}#{method_name}`"
-      arguments_desc = arguments.empty? ? "no arguments" : "arguments `#{arguments}`"
+      arguments_desc = arguments.empty? ? "no arguments" : "arguments `#{arguments.inspect}`"
       puts "Calling method #{full_name} with #{arguments_desc}"
       yield
     end
@@ -20,10 +20,12 @@ module Adornable
     end
 
     def self.memoize_for_arguments(method_receiver, method_name, arguments)
-      memo_var_name = :"@adornable_memoized_#{method_receiver.object_id}__#{method_name}__#{arguments}"
-      existing = instance_variable_get(memo_var_name)
-      value = existing.nil? ? yield : existing
-      instance_variable_set(memo_var_name, value)
+      memo_var_name = :"@adornable_memoized_for_arguments_#{method_receiver.object_id}_#{method_name}"
+      memo = instance_variable_get(memo_var_name) || {}
+      instance_variable_set(memo_var_name, memo)
+      args_key = arguments.inspect
+      memo[args_key] = yield if memo[args_key].nil?
+      memo[args_key]
     end
   end
 end

--- a/lib/adornable/version.rb
+++ b/lib/adornable/version.rb
@@ -1,3 +1,3 @@
 module Adornable
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
Fixes the following error:

```
     NameError:
       `@adornable_memoized_70239090195760__memoized_class_method_for_args__[[1, 2, 3], {:bar=>{:baz=>true, :bam=>[:hi, "there"]}}]' is not allowed as an instance variable name
     # ./lib/adornable/decorators.rb:24:in `instance_variable_get'
     # ./lib/adornable/decorators.rb:24:in `memoize_for_arguments'
     # ./lib/adornable/machinery.rb:89:in `run_decorators'
     # ./lib/adornable/machinery.rb:40:in `run_decorated_class_method'
     # ./lib/adornable.rb:46:in `block in singleton_method_added'
     # ./spec/adornable_spec.rb:505:in `block (5 levels) in <top (required)>'
```

Also adds tests for the built-in decorators `:log`, `:memoize`, and `:memoize_for_arguments`.