### PR TITLE
Add Rubocop (and fix related issues)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,59 @@
+require:
+  - rubocop-performance
+  - rubocop-rspec
+  - rubocop-rake
+
+# Layout
+
+Layout/LineLength:
+  Max: 120
+  Exclude:
+    - 'spec/**/*_spec.rb'
+    - 'test/**/*_spec.rb'
+
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
+
+# Metrics
+
+Metrics/AbcSize:
+  CountRepeatedAttributes: false
+  Exclude:
+    - 'spec/**/*_spec.rb'
+    - 'test/**/*_spec.rb'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+    - 'test/**/*_spec.rb'
+
+Metrics/ClassLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+    - 'test/**/*_spec.rb'
+
+# Rspec
+
+RSpec/ExampleLength:
+  Max: 20
+
+RSpec/MessageSpies:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Max: 5
+
+RSpec/NestedGroups:
+  Max: 10
+
+# Style
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/ExpandPathArguments:
+  Exclude:
+    - 'adornable.gemspec'
+
+Style/StringLiterals:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
     diff-lcs (1.4.4)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
     rake (10.5.0)
+    regexp_parser (2.0.3)
+    rexml (3.2.4)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -21,6 +28,27 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
+    rubocop (1.10.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    rubocop-performance (1.9.2)
+      rubocop (>= 0.90.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rake (0.5.1)
+      rubocop
+    rubocop-rspec (2.2.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
@@ -30,6 +58,10 @@ DEPENDENCIES
   bundler (~> 1.17)
   rake (~> 10.0)
   rspec (~> 3.0)
+  rubocop (~> 1.10)
+  rubocop-performance (~> 1.9)
+  rubocop-rake (~> 0.5)
+  rubocop-rspec (~> 2.2)
 
 BUNDLED WITH
    1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/adornable.gemspec
+++ b/adornable.gemspec
@@ -1,29 +1,35 @@
+# frozen_string_literal: true
 
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "adornable/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "adornable"
-  spec.version       = Adornable::VERSION
-  spec.authors       = ["Keegan Leitz"]
-  spec.email         = ["kjleitz@gmail.com"]
+  spec.name = "adornable"
+  spec.version = Adornable::VERSION
+  spec.authors = ["Keegan Leitz"]
+  spec.email = ["kjleitz@gmail.com"]
 
-  spec.summary       = "Method decorators for Ruby"
-  spec.description   = "Method decorators for Ruby"
-  spec.homepage      = "https://github.com/kjleitz/adornable"
-  spec.license       = "MIT"
+  spec.summary = "Method decorators for Ruby"
+  spec.description = "Method decorators for Ruby"
+  spec.homepage = "https://github.com/kjleitz/adornable"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 2.4.7"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop", "~> 1.10"
+  spec.add_development_dependency "rubocop-performance", "~> 1.9"
+  spec.add_development_dependency "rubocop-rake", "~> 0.5"
+  spec.add_development_dependency "rubocop-rspec", "~> 2.2"
 end

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "adornable"

--- a/lib/adornable.rb
+++ b/lib/adornable.rb
@@ -1,9 +1,13 @@
+# frozen_string_literal: true
+
 require "adornable/version"
 require "adornable/utils"
 require "adornable/error"
 require "adornable/decorators"
 require "adornable/machinery"
 
+# Extend the `Adornable` module in your class in order to have access to the
+# `decorate` and `add_decorators_from` macros.
 module Adornable
   def adornable_machinery
     @adornable_machinery ||= Adornable::Machinery.new
@@ -27,9 +31,10 @@ module Adornable
 
   def method_added(method_name)
     machinery = adornable_machinery # for local variable
-    return unless machinery.has_accumulated_decorators?
+    return unless machinery.accumulated_decorators?
+
     machinery.apply_accumulated_decorators_to_instance_method!(method_name)
-    original_method = self.instance_method(method_name)
+    original_method = instance_method(method_name)
     define_method(method_name) do |*args|
       bound_method = original_method.bind(self)
       machinery.run_decorated_instance_method(bound_method, *args)
@@ -39,9 +44,10 @@ module Adornable
 
   def singleton_method_added(method_name)
     machinery = adornable_machinery # for local variable
-    return unless machinery.has_accumulated_decorators?
+    return unless machinery.accumulated_decorators?
+
     machinery.apply_accumulated_decorators_to_class_method!(method_name)
-    original_method = self.method(method_name)
+    original_method = method(method_name)
     define_singleton_method(method_name) do |*args|
       machinery.run_decorated_class_method(original_method, *args)
     end

--- a/lib/adornable/decorators.rb
+++ b/lib/adornable/decorators.rb
@@ -1,4 +1,10 @@
+# frozen_string_literal: true
+
 module Adornable
+  # `Adornable::Decorators` is used as the default namespace for decorator
+  # methods when a decorator method that is neither explicitly sourced (via the
+  # `decorate from: <receiver>` option) nor implicitly sourced (via the
+  # `add_decorators_from <receiver>` macro).
   class Decorators
     def self.log(method_receiver, method_name, arguments)
       receiver_name, name_delimiter = if method_receiver.is_a?(Class)
@@ -12,7 +18,7 @@ module Adornable
       yield
     end
 
-    def self.memoize(method_receiver, method_name, arguments)
+    def self.memoize(method_receiver, method_name, _arguments)
       memo_var_name = :"@adornable_memoized_#{method_receiver.object_id}_#{method_name}"
       existing = instance_variable_get(memo_var_name)
       value = existing.nil? ? yield : existing

--- a/lib/adornable/error.rb
+++ b/lib/adornable/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Adornable
   module Error
     class Base < ::StandardError

--- a/lib/adornable/utils.rb
+++ b/lib/adornable/utils.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Adornable
-  class Utils
+  class Utils # :nodoc:
     class << self
       def blank?(value)
         value.nil? || (value.respond_to?(:empty?) && value.empty?)

--- a/lib/adornable/version.rb
+++ b/lib/adornable/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Adornable
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/spec/adornable_spec.rb
+++ b/spec/adornable_spec.rb
@@ -1,10 +1,15 @@
+# frozen_string_literal: true
+
+# rubocop:disable Lint/UnusedMethodArgument
 class FoobarExplicitDecorators
   def self.blast_it(method_receiver, method_name, arguments)
     value = yield
     "#{value}!"
   end
 end
+# rubocop:enable Lint/UnusedMethodArgument
 
+# rubocop:disable Lint/UnusedMethodArgument
 class FoobarImplicitDecorators
   def self.wait_for_it(method_receiver, method_name, arguments)
     value = yield
@@ -16,14 +21,18 @@ class FoobarImplicitDecorators
     "#{value}...!"
   end
 end
+# rubocop:enable Lint/UnusedMethodArgument
 
+# rubocop:disable Lint/UnusedMethodArgument
 class FoobarImplicitDecorators2
   def self.wait_for_it_excitedly(method_receiver, method_name, arguments)
     value = yield
     "#{value}...WOO!"
   end
 end
+# rubocop:enable Lint/UnusedMethodArgument
 
+# rubocop:disable Lint/UnusedMethodArgument
 class Foobar
   extend Adornable
 
@@ -72,6 +81,7 @@ class Foobar
 
   ###
 
+  # rubocop:disable Lint/DuplicateMethods
   decorate :log
   def shadowed_instance_method_both_have_decorator(foo, bar:)
     "we are in shadowed_instance_method_both_have_decorator"
@@ -81,9 +91,11 @@ class Foobar
   def shadowed_instance_method_both_have_decorator(foo, bar:)
     "we are in shadowed_instance_method_both_have_decorator"
   end
+  # rubocop:enable Lint/DuplicateMethods
 
   ###
 
+  # rubocop:disable Lint/DuplicateMethods
   decorate :log
   def shadowed_instance_method_decorator_removed(foo, bar:)
     "we are in shadowed_instance_method_decorator_removed"
@@ -92,9 +104,11 @@ class Foobar
   def shadowed_instance_method_decorator_removed(foo, bar:)
     "we are in shadowed_instance_method_decorator_removed"
   end
+  # rubocop:enable Lint/DuplicateMethods
 
   ###
 
+  # rubocop:disable Lint/DuplicateMethods
   def shadowed_instance_method_decorator_added(foo, bar:)
     "we are in shadowed_instance_method_decorator_added"
   end
@@ -103,9 +117,11 @@ class Foobar
   def shadowed_instance_method_decorator_added(foo, bar:)
     "we are in shadowed_instance_method_decorator_added"
   end
+  # rubocop:enable Lint/DuplicateMethods
 
   ###
 
+  # rubocop:disable Lint/DuplicateMethods
   decorate :log
   def self.shadowed_class_method_both_have_decorator(foo, bar:)
     "we are in self.shadowed_class_method_both_have_decorator"
@@ -115,9 +131,11 @@ class Foobar
   def self.shadowed_class_method_both_have_decorator(foo, bar:)
     "we are in self.shadowed_class_method_both_have_decorator"
   end
+  # rubocop:enable Lint/DuplicateMethods
 
   ###
 
+  # rubocop:disable Lint/DuplicateMethods
   decorate :log
   def self.shadowed_class_method_decorator_removed(foo, bar:)
     "we are in self.shadowed_class_method_decorator_removed"
@@ -126,9 +144,11 @@ class Foobar
   def self.shadowed_class_method_decorator_removed(foo, bar:)
     "we are in self.shadowed_class_method_decorator_removed"
   end
+  # rubocop:enable Lint/DuplicateMethods
 
   ###
 
+  # rubocop:disable Lint/DuplicateMethods
   def self.shadowed_class_method_decorator_added(foo, bar:)
     "we are in self.shadowed_class_method_decorator_added"
   end
@@ -137,6 +157,7 @@ class Foobar
   def self.shadowed_class_method_decorator_added(foo, bar:)
     "we are in self.shadowed_class_method_decorator_added"
   end
+  # rubocop:enable Lint/DuplicateMethods
 
   ###
 
@@ -232,13 +253,14 @@ class Foobar
     rand
   end
 end
+# rubocop:enable Lint/UnusedMethodArgument
 
 RSpec.describe Adornable do
   it "has a version number" do
     expect(Adornable::VERSION).not_to be nil
   end
 
-  context "instance methods" do
+  context "when decorating instance methods" do
     it "does not decorate undecorated instance methods" do
       foobar = Foobar.new
 
@@ -281,7 +303,7 @@ RSpec.describe Adornable do
     end
   end
 
-  context "class methods" do
+  context "when decorating class methods" do
     it "does not decorate undecorated class methods" do
       expect(Adornable::Decorators).not_to receive(:log)
 
@@ -318,7 +340,7 @@ RSpec.describe Adornable do
     end
   end
 
-  context "shadowed instance methods" do
+  context "when decorating shadowed instance methods" do
     it "only decorates once if both have decorators" do
       foobar = Foobar.new
 
@@ -355,7 +377,7 @@ RSpec.describe Adornable do
     end
   end
 
-  context "shadowed class methods" do
+  context "when decorating shadowed class methods" do
     it "only decorates once if both have decorators" do
       expect(Adornable::Decorators).to receive(:log).with(
         Foobar,
@@ -386,7 +408,7 @@ RSpec.describe Adornable do
     end
   end
 
-  context "using custom decorator methods explicitly" do
+  context "when using custom decorator methods explicitly" do
     it "decorates the instance method with a method found on the specified receiver" do
       foobar = Foobar.new
 
@@ -412,7 +434,7 @@ RSpec.describe Adornable do
     end
   end
 
-  context "using custom decorator methods implicitly" do
+  context "when using custom decorator methods implicitly" do
     it "decorates the instance method with a method found on the specified receiver" do
       foobar = Foobar.new
 
@@ -486,18 +508,18 @@ RSpec.describe Adornable do
     end
   end
 
-  context "using built-in decorators" do
+  context "when using built-in decorators" do
     describe ":log" do
-      context "for instance methods" do
+      context "when decorating instance methods" do
         it "logs the method with arguments to STDOUT" do
           foobar = Foobar.new
           normal_args = [123]
           keyword_args = { bar: { baz: [:hi, "there"] } }
-          all_args = [*normal_args, **keyword_args]
+          all_args = [*normal_args, keyword_args]
           expected_log = "Calling method `Foobar#logged_instance_method` with arguments `#{all_args.inspect}`\n"
-          expect {
+          expect do
             foobar.logged_instance_method(*normal_args, **keyword_args)
-          }.to output(expected_log).to_stdout
+          end.to output(expected_log).to_stdout
         end
 
         it "logs the method with no arguments to STDOUT" do
@@ -507,15 +529,15 @@ RSpec.describe Adornable do
         end
       end
 
-      context "for class methods" do
+      context "when decorating class methods" do
         it "logs the method with arguments to STDOUT" do
           normal_args = [123]
           keyword_args = { bar: { baz: [:hi, "there"] } }
-          all_args = [*normal_args, **keyword_args]
+          all_args = [*normal_args, keyword_args]
           expected_log = "Calling method `Foobar::logged_class_method` with arguments `#{all_args.inspect}`\n"
-          expect {
+          expect do
             Foobar.logged_class_method(*normal_args, **keyword_args)
-          }.to output(expected_log).to_stdout
+          end.to output(expected_log).to_stdout
         end
 
         it "logs the method with no arguments to STDOUT" do
@@ -526,7 +548,7 @@ RSpec.describe Adornable do
     end
 
     describe ":memoize" do
-      context "for instance methods" do
+      context "when decorating instance methods" do
         it "returns the cached value after being called" do
           foobar = Foobar.new
           value1 = foobar.memoized_instance_method(123, bar: 456)
@@ -537,7 +559,7 @@ RSpec.describe Adornable do
         end
       end
 
-      context "for class methods" do
+      context "when decorating class methods" do
         it "returns the cached value after being called" do
           value1 = Foobar.memoized_class_method(123, bar: 456)
           value2 = Foobar.memoized_class_method(123, bar: 456)
@@ -549,7 +571,7 @@ RSpec.describe Adornable do
     end
 
     describe ":memoize_for_arguments" do
-      context "for instance methods" do
+      context "when decorating instance methods" do
         it "returns the cached value when given the same simple arguments" do
           foobar = Foobar.new
           value1 = foobar.memoized_instance_method_for_args(123, bar: 456)
@@ -592,12 +614,12 @@ RSpec.describe Adornable do
           expect(value1).not_to eq(value2)
 
           value1 = foobar.memoized_instance_method_for_args([1, 2, 3], bar: { baz: true, bam: [:hi, "there"] })
-          value2 = foobar.memoized_instance_method_for_args([1, 2, 3], bar: { baz: true, bam: ["hi", "there"] })
+          value2 = foobar.memoized_instance_method_for_args([1, 2, 3], bar: { baz: true, bam: %w[hi there] })
           expect(value1).not_to eq(value2)
         end
       end
 
-      context "for class methods" do
+      context "when decorating class methods" do
         it "returns the cached value when given the same simple arguments" do
           value1 = Foobar.memoized_class_method_for_args(123, bar: 456)
           value2 = Foobar.memoized_class_method_for_args(123, bar: 456)
@@ -634,7 +656,7 @@ RSpec.describe Adornable do
           expect(value1).not_to eq(value2)
 
           value1 = Foobar.memoized_class_method_for_args([1, 2, 3], bar: { baz: true, bam: [:hi, "there"] })
-          value2 = Foobar.memoized_class_method_for_args([1, 2, 3], bar: { baz: true, bam: ["hi", "there"] })
+          value2 = Foobar.memoized_class_method_for_args([1, 2, 3], bar: { baz: true, bam: %w[hi there] })
           expect(value1).not_to eq(value2)
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 require "adornable"
 


### PR DESCRIPTION
- Adds the following `rubocop`-related gems:
  - `rubocop`
  - `rubocop-performance`
  - `rubocop-rake`
  - `rubocop-rspec`
- Adds `rubocop` configuration
- Fixes issues reported by `rubocop`