### PR TITLE
Implement memoization for methods which return nil values

### DIFF
--- a/lib/adornable/decorators.rb
+++ b/lib/adornable/decorators.rb
@@ -24,9 +24,12 @@ module Adornable
       method_receiver = context.method_receiver
       method_name = context.method_name
       memo_var_name = :"@adornable_memoized_#{method_receiver.object_id}_#{method_name}"
-      existing = instance_variable_get(memo_var_name)
-      value = existing.nil? ? yield : existing
-      instance_variable_set(memo_var_name, value)
+
+      if instance_variable_defined?(memo_var_name)
+        instance_variable_get(memo_var_name)
+      else
+        instance_variable_set(memo_var_name, yield)
+      end
     end
 
     def self.memoize_for_arguments(context)
@@ -37,7 +40,7 @@ module Adornable
       memo = instance_variable_get(memo_var_name) || {}
       instance_variable_set(memo_var_name, memo)
       args_key = method_args.inspect
-      memo[args_key] = yield if memo[args_key].nil?
+      memo[args_key] = yield unless memo.key?(args_key)
       memo[args_key]
     end
   end

--- a/spec/adornable_spec.rb
+++ b/spec/adornable_spec.rb
@@ -257,7 +257,7 @@ class Foobar
   decorate :memoize, for_any_arguments: true
   def memoized_instance_method_for_any_args_with_nil_return(counter)
     counter.value += 1
-    rand
+    nil
   end
 
   decorate :memoize

--- a/spec/adornable_spec.rb
+++ b/spec/adornable_spec.rb
@@ -249,6 +249,18 @@ class Foobar
   end
 
   decorate :memoize
+  def memoized_instance_method_for_args_with_nil_return(counter)
+    counter.value += 1
+    nil
+  end
+
+  decorate :memoize, for_any_arguments: true
+  def memoized_instance_method_for_any_args_with_nil_return(counter)
+    counter.value += 1
+    rand
+  end
+
+  decorate :memoize
   def self.memoized_class_method_for_args_as_default_option(foo, bar:)
     rand
   end
@@ -700,6 +712,24 @@ RSpec.describe Adornable do
           value1 = foobar.memoized_instance_method_for_args_as_default_option([1, 2, 3], bar: { baz: true, bam: [:hi, "there"] })
           value2 = foobar.memoized_instance_method_for_args_as_default_option([1, 2, 3], bar: { baz: true, bam: %w[hi there] })
           expect(value1).not_to eq(value2)
+        end
+
+        it "computes the value only once for args if the return value is nil" do
+          foobar = Foobar.new
+          counter = Struct.new(:value, :inspect).new(0, "struct")
+
+          foobar.memoized_instance_method_for_args_with_nil_return(counter)
+          foobar.memoized_instance_method_for_args_with_nil_return(counter)
+          expect(counter.value).to eq 1
+        end
+
+        it "computes the value only once for any args if the return value is nil" do
+          foobar = Foobar.new
+          counter = Struct.new(:value).new(0)
+
+          foobar.memoized_instance_method_for_any_args_with_nil_return(counter)
+          foobar.memoized_instance_method_for_any_args_with_nil_return(counter)
+          expect(counter.value).to eq 1
         end
       end
 


### PR DESCRIPTION
Current implementation runs the cached methods again if the return value is `nil`. I think this behavior is undesired. Let's assume there is an expensive computation performed in the method, which result in a `nil` return value. We should not run the method again, when the memoized method is recalled. I made simple script to verify current the behavior:

```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"

  gem "adornable"
end

class Data
  extend Adornable

  decorate :memoize
  def data
    puts "data called"
    "data"
  end

  decorate :memoize
  def null
    puts "null called"
  end
end

data = Data.new

puts data.data.inspect
puts data.data.inspect

puts data.null.inspect
puts data.null.inspect

# => data called
# => "data"
# => "data"
# => null called
# => nil
# => null called
# => nil
```

This PR changes the way how the checks for previous values are performed. It uses `hash.key?(name)` in place of `hash[name].nil?`. It also uses `instance_variable_defined?(memo_var_name)` instead of checking value returned by `instance_variable_get(memo_var_name)`. 

I tried to follow the style and logic used in the specs and implementation. Let me know if this change is desired. If so, I can gladly improve on the implementation or the specs following a guidance. :-)

After the changes above script returns:

```
# => data called
# => "data"
# => "data"
# => null called
# => nil
# => nil
```