### PR TITLE
Ruby 3 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - 3.2
+          - 3.1
+          - 3.0
           - 2.7
           - 2.6
           - 2.5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,7 @@ Layout/FirstArrayElementIndentation:
 # Metrics
 
 Metrics/AbcSize:
+  Max: 20
   CountRepeatedAttributes: false
   Exclude:
     - 'spec/**/*_spec.rb'
@@ -65,10 +66,13 @@ Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*_spec.rb'
 
+Metrics/ParameterLists:
+  CountKeywordArgs: false
+
 # Rspec
 
 RSpec/ExampleLength:
-  Max: 30
+  Max: 40
 
 RSpec/MessageSpies:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ require:
 
 AllCops:
   NewCops: enable
+  TargetRubyVersion: 2.5
 
 # Gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gemspec
 
 group :development, :test do
   gem "bundler", "~> 2.2"
+  gem "pry"
   gem "rake", "~> 13.0"
   gem "rspec", "~> 3.0"
   gem "rubocop", "~> 1.10"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Adornable provides the ability to cleanly decorate methods in Ruby. You can make
 
 ## Installation
 
+**NOTE:** This library is tested with Ruby versions 2.5.x through 3.2.x.
+
 ### Locally (to your application)
 
 Add the gem to your application's `Gemfile`:

--- a/README.md
+++ b/README.md
@@ -232,7 +232,9 @@ The **required argument** is an instance of `Adornable::Context`, which has some
 
 - `Adornable::Context#method_name`: the name of the decorated method being called (a symbol; e.g., `:some_method` or `:other_method`)
 - `Adornable::Context#method_receiver`: the actual object that the decorated method (the `#method_name`) belongs to/is being called on (an object/class; e.g., the class `Foo` if it's a decorated class method, or an instance of `Foo` if it's a decorated instance method)
-- `Adornable::Context#method_arguments`: an array of arguments passed to the decorated method, including keyword arguments as a final hash (e.g., if `:yet_another_method` was called like `Foo.new.yet_another_method(123, bar: true)` then `arguments` would be `[123, {:bar=>true}]`)
+- `Adornable::Context#method_arguments`: an array of arguments passed to the decorated method, including keyword arguments as a final hash (e.g., if `:yet_another_method` was called like `Foo.new.yet_another_method(123, bar: true, baz: 456)` then `method_arguments` would be `[123, {:bar=>true,:baz=>456}]`)
+- `Adornable::Context#method_positional_args`: an array of just the positional arguments passed to the decorated method, excluding keyword arguments (e.g., if `:yet_another_method` was called like `Foo.new.yet_another_method(123, bar: true, baz: 456)` then `method_positional_args` would be `[123]`)
+- `Adornable::Context#method_kwargs`: a hash of just the keyword arguments passed to the decorated method (e.g., if `:yet_another_method` was called like `Foo.new.yet_another_method(123, { bam: "hi" }, bar: true, baz: 456)` then `method_kwargs` would be `{:bar=>true,:baz=>456}`)
 
 ##### Custom keyword arguments (optional)
 

--- a/adornable.gemspec
+++ b/adornable.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description = "Adornable provides the ability to cleanly decorate methods in Ruby. You can make and use your own decorators, and you can also use some of the built-in ones that the gem provides. _Decorating_ methods is as simple as slapping a `decorate :some_decorator` above your method definition. _Defining_ decorators can be as simple as defining a method that yields to a block, or as complex as manipulating the decorated method's receiver and arguments, and/or changing the functionality of the decorator based on custom options supplied to it when initially applying the decorator." # rubocop:disable Layout/LineLength
   spec.homepage = "https://github.com/kjleitz/adornable"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.4.7"
+  spec.required_ruby_version = ">= 2.5.0"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/bin/asdf_switch
+++ b/bin/asdf_switch
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# First argument should be desired ruby version. If a partial version is given
+# (e.g., 2.6) and multiple versions are found to be installed (e.g., 2.6.9 and
+# 2.6.10), then the highest version (in semver version order) will be selected.
+SELECTED_RUBY_VERSION=$(asdf list ruby | sort -V | sed -e 's/^[[:space:]]*//' | grep "^$1" | tail -n 1)
+
+if [ -z "$SELECTED_RUBY_VERSION" ]; then
+  echo "Ruby version $1 is not installed. Try running:"
+  echo "  asdf install ruby $1"
+  exit 1
+fi
+
+echo "Using Ruby version $SELECTED_RUBY_VERSION"
+
+echo "(setting global Ruby)"
+asdf global ruby $SELECTED_RUBY_VERSION
+
+echo "(reshimming for this version)"
+asdf reshim ruby $SELECTED_RUBY_VERSION
+
+echo "(reinstalling bundled gems)"
+bundle install --redownload
+

--- a/lib/adornable.rb
+++ b/lib/adornable.rb
@@ -36,9 +36,9 @@ module Adornable
 
     machinery.apply_accumulated_decorators_to_instance_method!(method_name)
     original_method = instance_method(method_name)
-    define_method(method_name) do |*args|
+    define_method(method_name) do |*args, **kwargs|
       bound_method = original_method.bind(self)
-      machinery.run_decorated_instance_method(bound_method, *args)
+      machinery.run_decorated_instance_method(bound_method, *args, **kwargs)
     end
     super
   end
@@ -49,8 +49,8 @@ module Adornable
 
     machinery.apply_accumulated_decorators_to_class_method!(method_name)
     original_method = method(method_name)
-    define_singleton_method(method_name) do |*args|
-      machinery.run_decorated_class_method(original_method, *args)
+    define_singleton_method(method_name) do |*args, **kwargs|
+      machinery.run_decorated_class_method(original_method, *args, **kwargs)
     end
     super
   end

--- a/lib/adornable.rb
+++ b/lib/adornable.rb
@@ -36,10 +36,16 @@ module Adornable
 
     machinery.apply_accumulated_decorators_to_instance_method!(method_name)
     original_method = instance_method(method_name)
+
+    # NB: If you only supply `*args` to the block, you get kwargs as a trailing
+    # Hash member in the `args` array. If you supply both `*args, **kwargs` to
+    # the block, kwargs are excluded from the `args` array and only appear in
+    # the `kwargs` argument as a Hash.
     define_method(method_name) do |*args, **kwargs|
       bound_method = original_method.bind(self)
       machinery.run_decorated_instance_method(bound_method, *args, **kwargs)
     end
+
     super
   end
 
@@ -49,9 +55,15 @@ module Adornable
 
     machinery.apply_accumulated_decorators_to_class_method!(method_name)
     original_method = method(method_name)
+
+    # NB: If you only supply `*args` to the block, you get kwargs as a trailing
+    # Hash member in the `args` array. If you supply both `*args, **kwargs` to
+    # the block, kwargs are excluded from the `args` array and only appear in
+    # the `kwargs` argument as a Hash.
     define_singleton_method(method_name) do |*args, **kwargs|
       machinery.run_decorated_class_method(original_method, *args, **kwargs)
     end
+
     super
   end
 end

--- a/lib/adornable/context.rb
+++ b/lib/adornable/context.rb
@@ -8,14 +8,26 @@ module Adornable
       method_receiver
       method_name
       method_arguments
+      method_positional_args
+      method_kwargs
       decorator_name
       decorator_options
     ])
 
-    def initialize(method_receiver:, method_name:, method_arguments:, decorator_name:, decorator_options:)
+    def initialize(
+      method_receiver:,
+      method_name:,
+      method_arguments:,
+      method_positional_args:,
+      method_kwargs:,
+      decorator_name:,
+      decorator_options:
+    )
       @method_receiver = method_receiver
       @method_name = method_name
       @method_arguments = method_arguments
+      @method_positional_args = method_positional_args
+      @method_kwargs = method_kwargs
       @decorator_name = decorator_name
       @decorator_options = decorator_options
     end

--- a/lib/adornable/machinery.rb
+++ b/lib/adornable/machinery.rb
@@ -89,7 +89,9 @@ module Adornable
     end
 
     def run_decorators(decorators, bound_method, *method_positional_args, **method_kwargs)
-      return bound_method.call(*method_positional_args, **method_kwargs) if Adornable::Utils.blank?(decorators)
+      if Adornable::Utils.blank?(decorators)
+        return Adornable::Utils.empty_aware_send(bound_method, :call, method_positional_args, method_kwargs)
+      end
 
       decorator, *remaining_decorators = decorators
       decorator_name = decorator[:name]
@@ -119,13 +121,7 @@ module Adornable
         decorator_options: decorator_options,
       )
 
-      send_parameters = if Adornable::Utils.present?(decorator_options)
-        [decorator_name, context, decorator_options]
-      else
-        [decorator_name, context]
-      end
-
-      decorator_receiver.send(*send_parameters) do
+      Adornable::Utils.empty_aware_send(decorator_receiver, decorator_name, [context], decorator_options) do
         run_decorators(remaining_decorators, bound_method, *method_positional_args, **method_kwargs)
       end
     end

--- a/lib/adornable/utils.rb
+++ b/lib/adornable/utils.rb
@@ -23,6 +23,29 @@ module Adornable
         end
         "`#{receiver_name}#{name_delimiter}#{method_name}`"
       end
+
+      # This craziness is here because Ruby 2.6 and below don't like when you
+      # pass even _empty_ arguments to `#call` or `#send` or any other method
+      # with a splat, for callables that take no arguments. For example, this
+      # takes the place of:
+      #
+      #   receiver.send(method_name, *splat_args, **splat_kwargs)
+      #
+      # ...or:
+      #
+      #   receiver.some_method(*splat_args, **splat_kwargs)
+      #
+      # ...which is not cool <= 2.6.x apparently, if `#some_method` takes zero
+      # arguments even if both `splat_args` and `splat_kwargs` are empty (thus
+      # passing it zero arguments in actuality). Oh well.
+      #
+      def empty_aware_send(receiver, method_name, splat_args, splat_kwargs, &block)
+        return receiver.send(method_name, &block) if splat_args.empty? && splat_kwargs.empty?
+        return receiver.send(method_name, *splat_args, &block) if splat_kwargs.empty?
+        return receiver.send(method_name, **splat_kwargs, &block) if splat_args.empty?
+
+        receiver.send(method_name, *splat_args, **splat_kwargs, &block)
+      end
     end
   end
 end

--- a/spec/adornable_spec.rb
+++ b/spec/adornable_spec.rb
@@ -54,7 +54,7 @@ class Foobar
   end
 
   decorate :log
-  def some_instance_method_decorated(foo, bar:)
+  def some_instance_method_decorated(foo, bam, bar:, baz:)
     "we are in some_instance_method_decorated"
   end
 
@@ -305,13 +305,15 @@ RSpec.describe Adornable do
         expect(context).to be_a(Adornable::Context)
         expect(context.method_receiver).to eq(foobar)
         expect(context.method_name).to eq(:some_instance_method_decorated)
-        expect(context.method_arguments).to eq(["foo", { bar: "bar" }])
+        expect(context.method_arguments).to eq(["foo", { bam: "hi" }, { bar: "bar", baz: 123 }])
+        expect(context.method_positional_args).to eq(["foo", { bam: "hi" }])
+        expect(context.method_kwargs).to eq({ bar: "bar", baz: 123 })
         expect(context.decorator_name).to eq(:log)
         expect(context.decorator_options).to be_empty
         block.call
       end
 
-      returned = foobar.some_instance_method_decorated("foo", bar: "bar")
+      returned = foobar.some_instance_method_decorated("foo", { bam: "hi" }, bar: "bar", baz: 123)
       expect(returned).to eq("we are in some_instance_method_decorated")
       expect(decorator_called).to be true
     end
@@ -328,6 +330,8 @@ RSpec.describe Adornable do
         expect(context.method_receiver).to eq(foobar)
         expect(context.method_name).to eq(:some_instance_method_multi_decorated)
         expect(context.method_arguments).to eq(["foo", { bar: "bar" }])
+        expect(context.method_positional_args).to eq(["foo"])
+        expect(context.method_kwargs).to eq({ bar: "bar" })
         expect(context.decorator_name).to eq(:log)
         expect(context.decorator_options).to be_empty
         block.call
@@ -342,6 +346,8 @@ RSpec.describe Adornable do
         expect(context.method_receiver).to eq(foobar)
         expect(context.method_name).to eq(:some_instance_method_multi_decorated)
         expect(context.method_arguments).to eq(["foo", { bar: "bar" }])
+        expect(context.method_positional_args).to eq(["foo"])
+        expect(context.method_kwargs).to eq({ bar: "bar" })
         expect(context.decorator_name).to eq(:memoize)
         expect(context.decorator_options).to be_empty
         block.call
@@ -372,6 +378,8 @@ RSpec.describe Adornable do
         expect(context.method_receiver).to eq(Foobar)
         expect(context.method_name).to eq(:some_class_method_decorated)
         expect(context.method_arguments).to eq(["foo", { bar: "bar" }])
+        expect(context.method_positional_args).to eq(["foo"])
+        expect(context.method_kwargs).to eq({ bar: "bar" })
         expect(context.decorator_name).to eq(:log)
         expect(context.decorator_options).to be_empty
         block.call
@@ -392,6 +400,8 @@ RSpec.describe Adornable do
         expect(context.method_receiver).to eq(Foobar)
         expect(context.method_name).to eq(:some_class_method_multi_decorated)
         expect(context.method_arguments).to eq(["foo", { bar: "bar" }])
+        expect(context.method_positional_args).to eq(["foo"])
+        expect(context.method_kwargs).to eq({ bar: "bar" })
         expect(context.decorator_name).to eq(:log)
         expect(context.decorator_options).to be_empty
         block.call
@@ -406,6 +416,8 @@ RSpec.describe Adornable do
         expect(context.method_receiver).to eq(Foobar)
         expect(context.method_name).to eq(:some_class_method_multi_decorated)
         expect(context.method_arguments).to eq(["foo", { bar: "bar" }])
+        expect(context.method_positional_args).to eq(["foo"])
+        expect(context.method_kwargs).to eq({ bar: "bar" })
         expect(context.decorator_name).to eq(:memoize)
         expect(context.decorator_options).to be_empty
         block.call
@@ -431,6 +443,8 @@ RSpec.describe Adornable do
         expect(context.method_receiver).to eq(foobar)
         expect(context.method_name).to eq(:shadowed_instance_method_both_have_decorator)
         expect(context.method_arguments).to eq(["foo", { bar: "bar" }])
+        expect(context.method_positional_args).to eq(["foo"])
+        expect(context.method_kwargs).to eq({ bar: "bar" })
         expect(context.decorator_name).to eq(:log)
         expect(context.decorator_options).to be_empty
         block.call
@@ -462,6 +476,8 @@ RSpec.describe Adornable do
         expect(context.method_receiver).to eq(foobar)
         expect(context.method_name).to eq(:shadowed_instance_method_decorator_added)
         expect(context.method_arguments).to eq(["foo", { bar: "bar" }])
+        expect(context.method_positional_args).to eq(["foo"])
+        expect(context.method_kwargs).to eq({ bar: "bar" })
         expect(context.decorator_name).to eq(:log)
         expect(context.decorator_options).to be_empty
         block.call
@@ -484,6 +500,8 @@ RSpec.describe Adornable do
         expect(context.method_receiver).to eq(Foobar)
         expect(context.method_name).to eq(:shadowed_class_method_both_have_decorator)
         expect(context.method_arguments).to eq(["foo", { bar: "bar" }])
+        expect(context.method_positional_args).to eq(["foo"])
+        expect(context.method_kwargs).to eq({ bar: "bar" })
         expect(context.decorator_name).to eq(:log)
         expect(context.decorator_options).to be_empty
         block.call
@@ -511,6 +529,8 @@ RSpec.describe Adornable do
         expect(context.method_receiver).to eq(Foobar)
         expect(context.method_name).to eq(:shadowed_class_method_decorator_added)
         expect(context.method_arguments).to eq(["foo", { bar: "bar" }])
+        expect(context.method_positional_args).to eq(["foo"])
+        expect(context.method_kwargs).to eq({ bar: "bar" })
         expect(context.decorator_name).to eq(:log)
         expect(context.decorator_options).to be_empty
         block.call

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require "bundler/setup"
 require "adornable"
+require "pry"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
This is for backwards-compatibility between Ruby 2.x and Ruby 3.x; in v3 keyword arguments are treated differently than in v2 with respect to hash parameter equivalency. Previously, it was easy to just assume `method_arguments` could be an array with a hash at the end representing any given keyword arguments. However, in Ruby 3.x, we have to be able to distinguish between kwargs and trailing positional args of type `Hash`, so we'll shim `Adornable::Context#method_arguments` to look like it used to and then provide two new properties, `#method_positional_args` and `#method_kwargs`, to `Adornable::Context` for explicitness.