### PR TITLE
Add support to decorate methods with block arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ The **required argument** is an instance of `Adornable::Context`, which has some
 - `Adornable::Context#method_arguments`: an array of arguments passed to the decorated method, including keyword arguments as a final hash (e.g., if `:yet_another_method` was called like `Foo.new.yet_another_method(123, bar: true, baz: 456)` then `method_arguments` would be `[123, {:bar=>true,:baz=>456}]`)
 - `Adornable::Context#method_positional_args`: an array of just the positional arguments passed to the decorated method, excluding keyword arguments (e.g., if `:yet_another_method` was called like `Foo.new.yet_another_method(123, bar: true, baz: 456)` then `method_positional_args` would be `[123]`)
 - `Adornable::Context#method_kwargs`: a hash of just the keyword arguments passed to the decorated method (e.g., if `:yet_another_method` was called like `Foo.new.yet_another_method(123, { bam: "hi" }, bar: true, baz: 456)` then `method_kwargs` would be `{:bar=>true,:baz=>456}`)
+- `Adornable::Context#method_block`: a Proc object of a block argument passed to the decorated method
 
 ##### Custom keyword arguments (optional)
 

--- a/lib/adornable.rb
+++ b/lib/adornable.rb
@@ -41,9 +41,9 @@ module Adornable
     # Hash member in the `args` array. If you supply both `*args, **kwargs` to
     # the block, kwargs are excluded from the `args` array and only appear in
     # the `kwargs` argument as a Hash.
-    define_method(method_name) do |*args, **kwargs|
+    define_method(method_name) do |*args, **kwargs, &block|
       bound_method = original_method.bind(self)
-      machinery.run_decorated_instance_method(bound_method, *args, **kwargs)
+      machinery.run_decorated_instance_method(bound_method, *args, **kwargs, &block)
     end
 
     super
@@ -60,8 +60,8 @@ module Adornable
     # Hash member in the `args` array. If you supply both `*args, **kwargs` to
     # the block, kwargs are excluded from the `args` array and only appear in
     # the `kwargs` argument as a Hash.
-    define_singleton_method(method_name) do |*args, **kwargs|
-      machinery.run_decorated_class_method(original_method, *args, **kwargs)
+    define_singleton_method(method_name) do |*args, **kwargs, &block|
+      machinery.run_decorated_class_method(original_method, *args, **kwargs, &block)
     end
 
     super

--- a/lib/adornable/context.rb
+++ b/lib/adornable/context.rb
@@ -10,6 +10,7 @@ module Adornable
       method_arguments
       method_positional_args
       method_kwargs
+      method_block
       decorator_name
       decorator_options
     ])
@@ -20,6 +21,7 @@ module Adornable
       method_arguments:,
       method_positional_args:,
       method_kwargs:,
+      method_block:,
       decorator_name:,
       decorator_options:
     )
@@ -28,6 +30,7 @@ module Adornable
       @method_arguments = method_arguments
       @method_positional_args = method_positional_args
       @method_kwargs = method_kwargs
+      @method_block = method_block
       @decorator_name = decorator_name
       @decorator_options = decorator_options
     end

--- a/spec/adornable_spec.rb
+++ b/spec/adornable_spec.rb
@@ -220,12 +220,24 @@ class Foobar
   end
 
   decorate :log
+  def logged_instance_method_block_arg(foo, bar:, &block)
+    yield
+    rand
+  end
+
+  decorate :log
   def self.logged_class_method(foo, bar:)
     rand
   end
 
   decorate :log
   def self.logged_class_method_no_args
+    rand
+  end
+
+  decorate :log
+  def self.logged_class_method_block_arg(foo, bar:, &block)
+    yield
     rand
   end
 
@@ -609,6 +621,18 @@ RSpec.describe Adornable do
           expected_log = "Calling method `Foobar#logged_instance_method_no_args` with no arguments\n"
           expect { foobar.logged_instance_method_no_args }.to output(expected_log).to_stdout
         end
+
+        it "logs the method with normal, keyword, and block arguments to STDOUT" do
+          foobar = Foobar.new
+          normal_args = [123]
+          keyword_args = { bar: { baz: [:hi, "there"] } }
+          block = proc { rand }
+          all_args = [*normal_args, keyword_args, block]
+          expected_log = "Calling method `Foobar#logged_instance_method_block_arg` with arguments `#{all_args.inspect}`\n"
+          expect do
+            foobar.logged_instance_method_block_arg(*normal_args, **keyword_args, &block)
+          end.to output(expected_log).to_stdout
+        end
       end
 
       context "when decorating class methods" do
@@ -625,6 +649,17 @@ RSpec.describe Adornable do
         it "logs the method with no arguments to STDOUT" do
           expected_log = "Calling method `Foobar::logged_class_method_no_args` with no arguments\n"
           expect { Foobar.logged_class_method_no_args }.to output(expected_log).to_stdout
+        end
+
+        it "logs the method with normal, keyword, and block arguments to STDOUT" do
+          normal_args = [123]
+          keyword_args = { bar: { baz: [:hi, "there"] } }
+          block = proc { rand }
+          all_args = [*normal_args, keyword_args, block]
+          expected_log = "Calling method `Foobar::logged_class_method_block_arg` with arguments `#{all_args.inspect}`\n"
+          expect do
+            Foobar.logged_class_method_block_arg(*normal_args, **keyword_args, &block)
+          end.to output(expected_log).to_stdout
         end
       end
     end


### PR DESCRIPTION
This PR will add support to decorate methods with block arguments.

For example:

```rb
require 'adornable'

class Test
  extend Adornable

  decorate :log
  def foo(value)
    yield(value)
  end
end

test = Test.new
test.foo(42){|e| e.to_s}
# Calling method `Test#foo` with arguments `[42, #<Proc:0x0000000120e99870 (irb):13>]`
# => "42"
```

Related issue: #13